### PR TITLE
Use existing map by default instead of empty map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ profdata/*.profdata
 *.txt
 !conanfile.txt
 !vcpkg.json
+!resources/labirinth*.txt
 
 #ignore build_dirs
 .idea

--- a/Processors/Common/Game.cpp
+++ b/Processors/Common/Game.cpp
@@ -28,13 +28,13 @@ Game::Game():
 #ifdef MAKE_LOG
     renderer_ = new Renderer(isCurrentlyWorking_, logsSynchroStream_);
     processor_ = new MainProcessor(
-        WorldGenerator::generateWorld("../resources/labirinth.txt"), 
+        WorldGenerator::generateWorld("../resources/labirinth20x20.txt"), 
         logsSynchroStream_
     );
 #else
     renderer_ = new Renderer(isCurrentlyWorking_);
     processor_ = new MainProcessor(
-        WorldGenerator::generateWorld("../resources/labirinth.txt")
+        WorldGenerator::generateWorld("../resources/labirinth20x20.txt")
     );
 #endif
 

--- a/resources/labirinth.txt
+++ b/resources/labirinth.txt
@@ -1,0 +1,1 @@
+labirinth20x20.txt


### PR DESCRIPTION
This PR modifies the Game class to use the labirinth20x20.txt map by default instead of trying to load a non-existent labirinth.txt file and falling back to an empty map.

Changes:
- Modified Game.cpp to use labirinth20x20.txt directly
- Added a symlink from labirinth.txt to labirinth20x20.txt for backward compatibility
- Updated .gitignore to include map files in version control